### PR TITLE
fix: save url/source/category in sent_news.json

### DIFF
--- a/ai/main.py
+++ b/ai/main.py
@@ -116,7 +116,13 @@ def run_task():
         if mailer.send(subject, content):
             # 标记为已发送
             for item in new_items:
-                storage.mark_sent(item['id'], item['title'])
+                storage.mark_sent(
+                    item['id'],
+                    item['title'],
+                    link=item.get('link'),
+                    source=item.get('source'),
+                    category=item.get('category')
+                )
             print("所有新闻已发送并标记")
 
             # 索引到 Content Hub

--- a/ai/src/storage.py
+++ b/ai/src/storage.py
@@ -36,10 +36,13 @@ class Storage:
         """检查是否已发送"""
         return item_id in self.sent_items
 
-    def mark_sent(self, item_id, title):
+    def mark_sent(self, item_id, title, link=None, source=None, category=None):
         """标记为已发送"""
         self.sent_items[item_id] = {
             'title': title,
+            'link': link,
+            'source': source,
+            'category': category,
             'sent_at': datetime.now().isoformat()
         }
         self.save()

--- a/ecom/main.py
+++ b/ecom/main.py
@@ -65,7 +65,13 @@ def run_task():
         if mailer.send(subject, content):
             # 标记为已发送
             for item in new_items:
-                storage.mark_sent(item['id'], item['title'])
+                storage.mark_sent(
+                    item['id'],
+                    item['title'],
+                    link=item.get('link'),
+                    source=item.get('source'),
+                    category=item.get('category')
+                )
             print("所有新闻已发送并标记")
     else:
         print("没有新内容")

--- a/ecom/src/storage.py
+++ b/ecom/src/storage.py
@@ -36,10 +36,13 @@ class Storage:
         """检查是否已发送"""
         return item_id in self.sent_items
 
-    def mark_sent(self, item_id, title):
+    def mark_sent(self, item_id, title, link=None, source=None, category=None):
         """标记为已发送"""
         self.sent_items[item_id] = {
             'title': title,
+            'link': link,
+            'source': source,
+            'category': category,
             'sent_at': datetime.now().isoformat()
         }
         self.save()


### PR DESCRIPTION
Fixes #3

## Changes

Update `mark_sent()` to save additional fields:
- `link` (URL)
- `source`
- `category`

## Files modified

- `ai/src/storage.py`
- `ai/main.py`
- `ecom/src/storage.py`
- `ecom/main.py`

## New data structure

```json
{
  "435745fb...": {
    "title": "OpenAI says AI browsers...",
    "link": "https://...",
    "source": "TechCrunch AI",
    "category": "Agent 专项",
    "sent_at": "2025-12-23T13:10:42"
  }
}
```