### PR TITLE
fix: save daily report to S3

### DIFF
--- a/ai/main.py
+++ b/ai/main.py
@@ -125,6 +125,11 @@ def run_task():
                 )
             print("所有新闻已发送并标记")
 
+            # 保存到 S3
+            s3_config = config.get('s3', {})
+            if s3_config.get('enabled'):
+                storage.save_to_s3(content, new_items, ai_analysis, s3_config)
+
             # 索引到 Content Hub
             hub_enabled = config.get('hub.enabled', True)
             if hub_enabled:

--- a/ecom/main.py
+++ b/ecom/main.py
@@ -73,6 +73,11 @@ def run_task():
                     category=item.get('category')
                 )
             print("所有新闻已发送并标记")
+
+            # 保存到 S3
+            s3_config = config.get('s3', {})
+            if s3_config.get('enabled'):
+                storage.save_to_s3(content, new_items, ai_analysis, s3_config)
     else:
         print("没有新内容")
 


### PR DESCRIPTION
Fixes #5

## Changes

Add S3 save after email sent:
- `ai/main.py` - save to `s3://cls-whatsnew/ai/{date}.html/.json`
- `ecom/main.py` - save to `s3://cls-whatsnew/ecom/{date}.html/.json`

## Archive structure

```
s3://cls-whatsnew/
├── ai/
│   ├── 2026-02-08.html
│   └── 2026-02-08.json
└── ecom/
    ├── 2026-02-08.html
    └── 2026-02-08.json
```