### PR TITLE
docs: update documentation for Content Hub and S3 archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Content Hub Module**: New `hub/` directory for full-text storage and semantic search
+  - OpenSearch Serverless for vector + full-text search
+  - Cohere Multilingual v3 embedding (optimized for Chinese + English)
+  - Auto-index after daily report sent
+  - CLI: `python hub/main.py search "query"` for semantic search
+- **S3 Daily Report Archiving**: Daily reports now saved to S3
+  - HTML: `s3://cls-whatsnew/{ai|ecom}/{date}.html`
+  - JSON: `s3://cls-whatsnew/{ai|ecom}/{date}.json`
+- **Enhanced sent_news.json**: Now saves URL, source, and category for each news item
 - **E-commerce + AI Focus Mode**: New `ecom/` directory with dedicated config for e-commerce + AI content
 - **Key Companies Tracking**: Track specific companies (SHEIN, Amazon) across all news sources
 - **Company Aliases**: Broader matching with aliases (Amazon → aws, alexa, kindle, prime, etc.)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ AI-focused news aggregator with intelligent analysis powered by AWS Bedrock Clau
 
 ## Features
 
-- **AI Analysis**: 7-node LangGraph workflow (categorize, filter, score, enhance, translate, trends, summarize)
+- **AI Analysis**: 12-node LangGraph workflow for intelligent news processing
 - **Smart Filtering**: Auto-removes non-AI content, focuses on GenAI/LLM/Agentic AI
 - **Bilingual**: English to Chinese translation for all news
-- **Professional Email**: Modern HTML digest with TOP news picks and source grouping
-- **25+ AI Sources**: OpenAI, Anthropic, Google AI, DeepMind, Hugging Face, AWS blogs, etc.
+- **Professional Email**: Modern HTML digest with TOP news picks and category grouping
+- **35+ AI Sources**: OpenAI, Anthropic, Google AI, DeepMind, Hugging Face, AWS blogs, etc.
+- **Content Hub**: Full-text storage with semantic search (OpenSearch + Cohere Embedding)
+- **S3 Archiving**: Daily reports archived to S3 (HTML + JSON)
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Fixes #7 - Update documentation to reflect new Content Hub module and S3 archiving features.

### Changes

**CHANGELOG.md**:
- Added Content Hub Module section (OpenSearch + Cohere)
- Added S3 Daily Report Archiving
- Added Enhanced sent_news.json entry

**README.md**:
- Updated features list with Content Hub and S3 Archiving
- Updated workflow description (7-node → 12-node)
- Updated source count (25+ → 35+)

**DESIGN.md**:
- Added Content Hub section with storage, embedding, and search details
- Updated module structure to show hub/ directory
- Updated data flow to include S3 archive and Hub index hooks
- Marked Content Hub and S3 archiving as completed in Pending Improvements

## Test Plan

- [x] Verify all documentation changes are accurate
- [x] Ensure consistency across CHANGELOG, README, and DESIGN docs