### PR TITLE
store S3 snapshot paths in OpenSearch

### DIFF
--- a/ai/main.py
+++ b/ai/main.py
@@ -69,6 +69,12 @@ def index_to_hub(items):
                         )
                         if result:
                             captured += 1
+                            # 更新 OpenSearch 中的快照路径
+                            storage.update_snapshot(article_id, {
+                                'screenshot_s3': result.get('screenshot_s3', ''),
+                                'html_s3': result.get('html_s3', ''),
+                                'images_s3': result.get('images_s3', [])
+                            })
                     except Exception as e:
                         print(f"[Hub] 完整抓取失败 {url}: {e}")
 


### PR DESCRIPTION
## Summary

Store S3 snapshot paths (screenshot, HTML, images) in OpenSearch so that search results include direct links to the complete page archive.

## Changes

**hub/src/storage.py**:
- Added `screenshot_s3`, `html_s3`, `images_s3` fields to index mapping
- Added `update_snapshot()` method to update snapshot paths after capture

**ai/main.py**:
- Call `storage.update_snapshot()` after browser_fetcher capture

## OpenSearch Document Schema

```json
{
  "title": "...",
  "content": "...",
  "embedding": [...],
  "url": "https://...",
  "screenshot_s3": "s3://cls-whatsnew/hub/screenshots/{id}.png",
  "html_s3": "s3://cls-whatsnew/hub/html/{id}.html",
  "images_s3": ["s3://.../*.png", "..."]
}
```

## Usage

Search results now include snapshot links:
```python
results = search.search("LangGraph")
for r in results:
    print(r['screenshot_s3'])  # Direct link to screenshot
    print(r['html_s3'])        # Direct link to HTML
```