### PR TITLE
reorganize S3 folder structure by article ID

### DIFF
--- a/hub/src/browser_fetcher.py
+++ b/hub/src/browser_fetcher.py
@@ -142,10 +142,11 @@ class BrowserFetcher:
                 # 保存截图
                 if save_screenshot:
                     screenshot = page.screenshot(full_page=True, type='png')
-                    screenshot_key = f"{self.prefix}/screenshots/{article_id}.png"
+                    screenshot_key = f"{self.prefix}/{article_id}/screenshot.png"
 
                     # 本地保存
-                    local_path = self.local_dir / f"{article_id}.png"
+                    local_path = self.local_dir / article_id / "screenshot.png"
+                    local_path.parent.mkdir(parents=True, exist_ok=True)
                     local_path.write_bytes(screenshot)
                     result['screenshot_local'] = str(local_path)
 
@@ -164,10 +165,11 @@ class BrowserFetcher:
                 if save_html:
                     # 获取完整 HTML
                     html = page.content()
-                    html_key = f"{self.prefix}/html/{article_id}.html"
+                    html_key = f"{self.prefix}/{article_id}/page.html"
 
                     # 本地保存
-                    local_html = self.local_dir / f"{article_id}.html"
+                    local_html = self.local_dir / article_id / "page.html"
+                    local_html.parent.mkdir(parents=True, exist_ok=True)
                     local_html.write_text(html, encoding='utf-8')
                     result['html_local'] = str(local_html)
 
@@ -194,7 +196,7 @@ class BrowserFetcher:
                     for img in saved_images:
                         if img.get('local_path'):
                             local_path = Path(img['local_path'])
-                            s3_key = f"{self.prefix}/images/{article_id}/{local_path.name}"
+                            s3_key = f"{self.prefix}/{article_id}/images/{local_path.name}"
                             self.s3.put_object(
                                 Bucket=self.bucket,
                                 Key=s3_key,
@@ -208,7 +210,7 @@ class BrowserFetcher:
                 browser.close()
 
                 # 保存元数据
-                meta_key = f"{self.prefix}/meta/{article_id}.json"
+                meta_key = f"{self.prefix}/{article_id}/meta.json"
                 if save_to_s3:
                     self.s3.put_object(
                         Bucket=self.bucket,

--- a/hub/src/storage.py
+++ b/hub/src/storage.py
@@ -330,10 +330,8 @@ class ContentStorage:
             bucket = self.s3_config.get('bucket', 'cls-whatsnew')
             prefix = self.s3_config.get('prefix', 'hub')
 
-            beijing_tz = timezone(timedelta(hours=8))
-            date_str = datetime.now(beijing_tz).strftime('%Y-%m-%d')
-
-            key = f"{prefix}/articles/{date_str}/{article['id']}.json"
+            # 按文章 ID 组织目录
+            key = f"{prefix}/{article['id']}/article.json"
 
             s3.put_object(
                 Bucket=bucket,


### PR DESCRIPTION
## Summary

Change S3 folder structure from content-type based to article-based organization.

## Before
```
hub/screenshots/{id}.png
hub/html/{id}.html
hub/images/{id}/
hub/articles/{date}/{id}.json
hub/meta/{id}.json
```

## After
```
hub/{id}/
├── screenshot.png
├── page.html
├── article.json
├── meta.json
└── images/
    ├── 000.png
    └── ...
```

## Benefits
- All content for one article grouped together
- Easier to manage/delete article data
- Cleaner folder structure