### PR TITLE
store folder_name in OpenSearch

### DIFF
--- a/ai/main.py
+++ b/ai/main.py
@@ -71,6 +71,7 @@ def index_to_hub(items):
                             captured += 1
                             # 更新 OpenSearch 中的快照路径
                             storage.update_snapshot(article_id, {
+                                'folder_name': result.get('folder_name', ''),
                                 'screenshot_s3': result.get('screenshot_s3', ''),
                                 'html_s3': result.get('html_s3', ''),
                                 'images_s3': result.get('images_s3', [])

--- a/hub/src/storage.py
+++ b/hub/src/storage.py
@@ -206,6 +206,7 @@ class ContentStorage:
                 # 更新快照字段
                 update_body = {
                     "doc": {
+                        "folder_name": snapshot.get('folder_name', ''),
                         "screenshot_s3": snapshot.get('screenshot_s3', ''),
                         "html_s3": snapshot.get('html_s3', ''),
                         "images_s3": snapshot.get('images_s3', [])


### PR DESCRIPTION
## Summary

Add `folder_name` to OpenSearch document when updating snapshot paths.

## Changes

- **hub/src/storage.py**: Add `folder_name` field to update_snapshot
- **ai/main.py**: Pass `folder_name` from browser_fetcher result

## OpenSearch Document

```json
{
  "title": "...",
  "folder_name": "2026-02-08_Tool-Calling-with-LangChain_e9b521bc",
  "screenshot_s3": "s3://cls-whatsnew/hub/2026-02-08_.../screenshot.png",
  "html_s3": "s3://cls-whatsnew/hub/2026-02-08_.../page.html",
  ...
}
```