### PR TITLE
docs: update S3 folder structure and OpenSearch schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Image download and S3 upload
   - JavaScript rendering for SPA pages
   - Lazy-load image handling
+- **S3 Folder Reorganization**: Content organized by article with readable names
+  - Format: `hub/{date}_{title}_{short_id}/`
+  - Example: `hub/2026-02-08_LangGraph-Cloud_d77d3855/`
+  - Each folder contains: screenshot.png, page.html, article.json, meta.json, images/
+- **OpenSearch Snapshot Paths**: S3 paths stored in search index
+  - `folder_name`: Readable folder name for S3 path
+  - `screenshot_s3`: Direct link to full-page screenshot
+  - `html_s3`: Direct link to archived HTML
+  - `images_s3`: List of article image paths
 - **S3 Daily Report Archiving**: Daily reports now saved to S3
   - HTML: `s3://cls-whatsnew/{ai|ecom}/{date}.html`
   - JSON: `s3://cls-whatsnew/{ai|ecom}/{date}.json`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -234,7 +234,11 @@ Daily Report Sent
       "category": {"type": "keyword"},
       "published_at": {"type": "date"},
       "url": {"type": "keyword"},
-      "indexed_at": {"type": "date"}
+      "indexed_at": {"type": "date"},
+      "folder_name": {"type": "keyword"},
+      "screenshot_s3": {"type": "keyword"},
+      "html_s3": {"type": "keyword"},
+      "images_s3": {"type": "keyword"}
     }
   }
 }
@@ -270,12 +274,16 @@ python hub/main.py stats                      # 统计信息
 **S3 存储结构:**
 ```
 s3://cls-whatsnew/hub/
-├── screenshots/{id}.png    # 全页截图
-├── html/{id}.html          # 完整 HTML
-├── images/{id}/            # 文章图片
-│   ├── 000.png
-│   └── ...
-└── meta/{id}.json          # 元数据
+└── {date}_{title}_{short_id}/    # 可读的文章目录名
+    ├── screenshot.png             # 全页截图
+    ├── page.html                  # 完整 HTML
+    ├── article.json               # 文章文本内容
+    ├── meta.json                  # 抓取元数据
+    └── images/                    # 文章图片
+        ├── 000.png
+        └── ...
+
+示例: hub/2026-02-08_LangGraph-Cloud_d77d3855/
 ```
 
 ---


### PR DESCRIPTION
## Summary

Update documentation for recent S3 and OpenSearch changes (PR #13-#16).

## Changes

**CHANGELOG.md**:
- Added S3 Folder Reorganization section
- Added OpenSearch Snapshot Paths section

**DESIGN.md**:
- Updated S3 storage structure to show new format: `{date}_{title}_{short_id}/`
- Added new OpenSearch fields: `folder_name`, `screenshot_s3`, `html_s3`, `images_s3`

## New S3 Structure

```
hub/2026-02-08_LangGraph-Cloud_d77d3855/
├── screenshot.png
├── page.html
├── article.json
├── meta.json
└── images/
```