### PR TITLE
fix published date extraction for all sources

### DIFF
--- a/ai/main.py
+++ b/ai/main.py
@@ -47,7 +47,8 @@ def index_to_hub(items):
                 metadata = {
                     'title': item.get('title'),
                     'source': item.get('source'),
-                    'category': item.get('category')
+                    'category': item.get('category'),
+                    'published': item.get('published')
                 }
 
                 # 1. 抓取全文并索引到 OpenSearch (快速)

--- a/ai/src/crawler.py
+++ b/ai/src/crawler.py
@@ -176,12 +176,24 @@ class Crawler:
                     keyword_filtered += 1
                     continue
 
+                # 提取发布日期 (优先使用 parsed 格式)
+                pub_date = ''
+                published_time = entry.get('published_parsed') or entry.get('updated_parsed')
+                if published_time:
+                    try:
+                        pub_date = datetime(*published_time[:6]).strftime('%Y-%m-%d')
+                    except:
+                        pass
+                if not pub_date:
+                    # 回退到字符串格式
+                    pub_date = entry.get('published', '') or entry.get('updated', '')
+
                 item = {
                     'id': item_id,
                     'title': title,
                     'link': entry.get('link', ''),
                     'summary': summary,
-                    'published': entry.get('published', ''),
+                    'published': pub_date,
                     'source': source_name
                 }
 
@@ -381,7 +393,7 @@ class Crawler:
                         'title': title,
                         'link': href,
                         'summary': title,  # 简化，不获取详情
-                        'published': '',
+                        'published': datetime.now().strftime('%Y-%m-%d'),
                         'source': source_name
                     }
 
@@ -503,7 +515,7 @@ class Crawler:
                         'title': title,
                         'link': full_url,
                         'summary': title,
-                        'published': '',
+                        'published': datetime.now().strftime('%Y-%m-%d'),
                         'source': source_name
                     }
 
@@ -561,7 +573,7 @@ class Crawler:
                         'title': title,
                         'link': full_url,
                         'summary': title,
-                        'published': '',
+                        'published': datetime.now().strftime('%Y-%m-%d'),
                         'source': source_name
                     }
 
@@ -619,7 +631,7 @@ class Crawler:
                         'title': title,
                         'link': full_url,
                         'summary': title,
-                        'published': '',
+                        'published': datetime.now().strftime('%Y-%m-%d'),
                         'source': source_name
                     }
 
@@ -677,7 +689,7 @@ class Crawler:
                         'title': title,
                         'link': full_url,
                         'summary': title,
-                        'published': '',
+                        'published': datetime.now().strftime('%Y-%m-%d'),
                         'source': source_name
                     }
 

--- a/ecom/src/crawler.py
+++ b/ecom/src/crawler.py
@@ -258,12 +258,23 @@ class Crawler:
                     keyword_filtered += 1
                     continue
 
+                # 提取发布日期 (优先使用 parsed 格式)
+                pub_date = ''
+                published_time = entry.get('published_parsed') or entry.get('updated_parsed')
+                if published_time:
+                    try:
+                        pub_date = datetime(*published_time[:6]).strftime('%Y-%m-%d')
+                    except:
+                        pass
+                if not pub_date:
+                    pub_date = entry.get('published', '') or entry.get('updated', '')
+
                 item = {
                     'id': item_id,
                     'title': title,
                     'link': entry.get('link', ''),
                     'summary': summary,
-                    'published': entry.get('published', ''),
+                    'published': pub_date,
                     'source': source_name,
                     'is_key_company': is_key_company  # 标记是否为关键企业新闻
                 }
@@ -434,7 +445,7 @@ class Crawler:
                         'title': title,
                         'link': href,
                         'summary': title,  # 简化，不获取详情
-                        'published': '',
+                        'published': datetime.now().strftime('%Y-%m-%d'),
                         'source': source_name
                     }
 
@@ -563,7 +574,7 @@ class Crawler:
                             'title': title,
                             'link': full_url,
                             'summary': title,  # 使用标题作为摘要
-                            'published': '',
+                            'published': datetime.now().strftime('%Y-%m-%d'),
                             'source': source_name,
                             'is_key_company': True  # 标记为关键企业
                         }
@@ -638,7 +649,7 @@ class Crawler:
                     'title': title,
                     'link': full_url,
                     'summary': title,
-                    'published': '',
+                    'published': datetime.now().strftime('%Y-%m-%d'),
                     'source': source_name,
                     'is_key_company': True  # 标记为关键企业
                 }

--- a/hub/src/fetcher.py
+++ b/hub/src/fetcher.py
@@ -82,13 +82,15 @@ class ContentFetcher:
 
             # 构建结果
             beijing_tz = timezone(timedelta(hours=8))
+            # 优先使用 metadata 中的日期，否则使用提取的日期
+            pub_date = (metadata or {}).get('published') or extracted_date
             result = {
                 'id': article_id,
                 'url': url,
                 'title': (metadata or {}).get('title') or extracted_title or '',
                 'content': content,
                 'author': extracted_author,
-                'published_at': self._parse_date(extracted_date),
+                'published_at': self._parse_date(pub_date),
                 'source': (metadata or {}).get('source', ''),
                 'category': (metadata or {}).get('category', ''),
                 'fetched_at': datetime.now(beijing_tz).isoformat(),


### PR DESCRIPTION
## Summary

Fixes #22 - All articles were missing the `published` date field.

## Changes

### ai/src/crawler.py & ecom/src/crawler.py
- Use `published_parsed` / `updated_parsed` from RSS feeds (more reliable)
- Format as `YYYY-MM-DD` string
- Fallback to today's date for web scrapers without date info

### ai/main.py
- Pass `published` field to Content Hub metadata

### hub/src/fetcher.py
- Prioritize metadata `published` over extracted date

## Before
```
1. Claude Opus 4.6
   published: ""
```

## After
```
1. Claude Opus 4.6
   published: "2026-02-10"
```